### PR TITLE
Remove Up Core, Up Core Plus, Up Squared

### DIFF
--- a/config.json
+++ b/config.json
@@ -226,21 +226,6 @@
       "repo": "balena-os/balena-up-board"
     },
     {
-      "name": "UP Core",
-      "slug": "up-core",
-      "repo": "balena-os/balena-up-board"
-    },
-    {
-      "name": "UP Core Plus",
-      "slug": "up-core-plus",
-      "repo": "balena-os/balena-up-board"
-    },
-    {
-      "name": "UP Squared",
-      "slug": "up-squared",
-      "repo": "balena-os/balena-up-board"
-    },
-    {
       "name": "Variscite DART-6UL",
       "slug": "imx6ul-var-dart",
       "repo": "balena-os/balena-variscite"


### PR DESCRIPTION
It was decided in an arch call that going forward we will
be maintaining 1 general image for all Up boards.

Signed-off-by: Florin Sarbu <florin@balena.io>